### PR TITLE
change usb buffer size for optimize sdl transport

### DIFF
--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
@@ -80,6 +80,7 @@ class UsbConnection : public Connection {
   uint8_t out_endpoint_;
   uint16_t out_endpoint_max_packet_size_;
   unsigned char* in_buffer_;
+  uint16_t in_buffer_size_;
   libusb_transfer* in_transfer_;
   libusb_transfer* out_transfer_;
 

--- a/src/components/transport_manager/src/usb/libusb/usb_connection.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_connection.cc
@@ -43,6 +43,8 @@
 
 #include "utils/logger.h"
 
+#define	TRANSPORT_USB_BUFFER_MAX_SIZE		(16*1024)
+
 namespace transport_manager {
 namespace transport_adapter {
 
@@ -64,6 +66,7 @@ UsbConnection::UsbConnection(const DeviceUID& device_uid,
     , out_endpoint_(0)
     , out_endpoint_max_packet_size_(0)
     , in_buffer_(NULL)
+    , in_buffer_size_(0)
     , in_transfer_(NULL)
     , out_transfer_(0)
     , out_messages_()
@@ -96,7 +99,7 @@ bool UsbConnection::PostInTransfer() {
                             device_handle_,
                             in_endpoint_,
                             in_buffer_,
-                            in_endpoint_max_packet_size_,
+                            in_buffer_size_,
                             InTransferCallback,
                             this,
                             0);
@@ -307,7 +310,15 @@ bool UsbConnection::Init() {
     LOG4CXX_TRACE(logger_, "exit with FALSE. Condition: !FindEndpoints()");
     return false;
   }
-  in_buffer_ = new unsigned char[in_endpoint_max_packet_size_];
+
+  if(in_endpoint_max_packet_size_ < TRANSPORT_USB_BUFFER_MAX_SIZE){
+  	in_buffer_size_ = TRANSPORT_USB_BUFFER_MAX_SIZE;
+  }
+  else {
+  	in_buffer_size_ = in_endpoint_max_packet_size_;
+  }
+
+  in_buffer_ = new unsigned char[in_buffer_size_];
   in_transfer_ = libusb_alloc_transfer(0);
   if (NULL == in_transfer_) {
     LOG4CXX_ERROR(logger_, "libusb_alloc_transfer failed");


### PR DESCRIPTION
修正了sdl_core在传输视频流时，由于注册到libusb的接收缓存设置偏小为512B，导致单个视频帧被分片的片数过多，大量的分片在经过Transport的队列传递到Protocol时，队列的异步读写次数过多，影响了sdl_core的视频传输性能的问题。修改注册到libusb的接收缓存大小到16KB，能有效减少视频帧分片数，减少Transport的传输队列的异步读写次数，提升sdl_core的视频数据传输性能。


